### PR TITLE
Refactor redirect URL construction

### DIFF
--- a/lib/cegela/server.ex
+++ b/lib/cegela/server.ex
@@ -26,16 +26,10 @@ defmodule Cegela.Server do
   end
 
   match _ do
-    uri =
-      struct(URI, %{
-        scheme: "https",
-        host: "bit.ly",
-        path: conn.request_path,
-        query: conn.query_string
-      })
+    url = URI.merge("https://bit.ly", "#{conn.request_path}?#{conn.query_string}")
 
     conn
-    |> put_resp_header("location", to_string(uri))
-    |> send_resp(301, "")
+    |> put_resp_header("location", to_string(url))
+    |> send_resp(301, "Moved to #{url}")
   end
 end

--- a/test/cegela/server_test.exs
+++ b/test/cegela/server_test.exs
@@ -1,6 +1,8 @@
 defmodule CegelaTest do
   use ExUnit.Case, async: true
-  use Plug.Test
+
+  import Plug.Test
+  import Plug.Conn
 
   alias Cegela.Server
   alias Plug.Conn

--- a/test/cegela/static_test.exs
+++ b/test/cegela/static_test.exs
@@ -1,6 +1,8 @@
 defmodule Cegela.StaticTest do
   use ExUnit.Case, async: true
-  use Plug.Test
+
+  import Plug.Test
+  import Plug.Conn
 
   alias Cegela.Static
 


### PR DESCRIPTION
Do not use a struct directly.
Also fixes `use Plug.Test` deprecation warning